### PR TITLE
Implement join rate limiting and /report

### DIFF
--- a/furcastbot/furcastbot.py
+++ b/furcastbot/furcastbot.py
@@ -28,9 +28,9 @@ from telegram.ext import (
     CallbackQueryHandler,
     CommandHandler,
     Dispatcher,
-    Updater,
-    MessageHandler,
     Filters,
+    MessageHandler,
+    Updater,
 )
 
 load_dotenv()

--- a/furcastbot/furcastbot.py
+++ b/furcastbot/furcastbot.py
@@ -474,10 +474,11 @@ def report(update: Update, context: CallbackContext) -> None:
             mention = update.message.from_user.mention_html()
             summon_link = update.message.link
             reply_link = update.message.reply_to_message.link
+            update.message.reply_to_message.forward(admin_chat)
             context.bot.send_message(
                 admin_chat,
                 f'{mention} has <a href="{summon_link}">summoned</a> admins in reply '
-                f'to <a href="{reply_link}">a message</a>; they said:\n'
+                f'to <a href="{reply_link}">the above message</a>; they said:\n'
                 f"{update.message.text}",
                 parse_mode=ParseMode.HTML,
             )

--- a/furcastbot/furcastbot.py
+++ b/furcastbot/furcastbot.py
@@ -474,12 +474,13 @@ def report(update: Update, context: CallbackContext) -> None:
             mention = update.message.from_user.mention_html()
             summon_link = update.message.link
             reply_link = update.message.reply_to_message.link
+            escaped_report_text = escape(update.message.text)
             update.message.reply_to_message.forward(admin_chat)
             context.bot.send_message(
                 admin_chat,
                 f'{mention} has <a href="{summon_link}">summoned</a> admins in reply '
                 f'to <a href="{reply_link}">the above message</a>; they said:\n'
-                f"{update.message.text}",
+                f"{escaped_report_text}",
                 parse_mode=ParseMode.HTML,
             )
             update.message.reply_text("Thank you; we’re on it.")


### PR DESCRIPTION
This implements join rate-limiting, preventing new links from being issued more than once every 10 minutes, and also issues unique invite links per user, to make it more difficult for raiders to join the group en masse.

It also adds a /report command that does slightly more than the existing one.