### PR TITLE
Add rc.d script for OpenBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,18 @@ version - Print the source link and GCF version if available
   * `pip install --upgrade .`
   * `deactivate`
   * `venv/bin/furcastbot` to verify functionality
-  * `sudo loginctl enable-linger bots`
-  * `ln -s ../../../furcast-tg-bot/contrib/furcastbot.service
-    ~/.config/systemd/user/furcastbot.service`
-  * `systemctl --user daemon-reload`
-  * `systemctl --user enable --now furcastbot`
+  * For `systemd`:
+    * `sudo loginctl enable-linger bots`
+    * `ln -s ../../../furcast-tg-bot/contrib/furcastbot.service
+      ~/.config/systemd/user/furcastbot.service`
+    * `systemctl --user daemon-reload`
+    * `systemctl --user enable --now furcastbot`
+  * For OpenBSD (and maybe other sysv-style init systems, we haven't checked):
+    * `doas cp ../../../furcast-tg-bot/contrib/openbsd.rc /etc/rc.d/furcast_bot`
+    * `doas chmod +x /etc/rc.d/furcast_bot`
+    * `doas rcctl start furcast_bot`
+    * `doas rcctl enable furcast_bot`
+    * (If you want to run multiple copies of the bot, we recommend copying the rc script and fiddling with the variables, rather than symlinking and using `rcctl set service_name flags`, since the config file is not read from the flags.)
 
 * Otherwise, for webhooks:
   * Set up a

--- a/contrib/openbsd.rc
+++ b/contrib/openbsd.rc
@@ -1,0 +1,23 @@
+#!/bin/ksh
+
+daemon_execdir=/home/furcast-bot/furcast-tg-bot
+daemon_user=furcast-bot
+daemon=tmux
+daemon_tmux_session="furcast-bot"
+daemon_flags="new-session -d -n bot -s ${daemon_tmux_session} '/home/furcast-bot/venv/bin/python furcastbot/furcastbot.py'"
+
+. /etc/rc.d/rc.subr
+
+rc_bg=YES
+
+rc_reload=NO
+
+rc_stop() {
+		rc_exec "tmux kill-session -t ${daemon_tmux_session}"
+}
+
+rc_check() {
+		rc_exec "tmux list-sessions | grep -q ${daemon_tmux_session}"
+}
+
+rc_cmd $1

--- a/contrib/openbsd.rc
+++ b/contrib/openbsd.rc
@@ -1,10 +1,12 @@
 #!/bin/ksh
 
-daemon_execdir=/home/furcast-bot/furcast-tg-bot
-daemon_user=furcast-bot
-daemon=tmux
-daemon_tmux_session="furcast-bot"
-daemon_flags="new-session -d -n bot -s ${daemon_tmux_session} '/home/furcast-bot/venv/bin/python furcastbot/furcastbot.py'"
+daemon_user=bots
+daemon_home=$(eval echo ~$daemon_user)
+daemon_execdir=${daemon_home}/furcast-tg-bot
+daemon="${daemon_home}/venv/bin/python"
+
+daemon_flags="furcastbot/furcastbot.py"
+daemon_log=/var/log/furcast-bot.log
 
 . /etc/rc.d/rc.subr
 
@@ -12,12 +14,8 @@ rc_bg=YES
 
 rc_reload=NO
 
-rc_stop() {
-		rc_exec "tmux kill-session -t ${daemon_tmux_session}"
-}
-
-rc_check() {
-		rc_exec "tmux list-sessions | grep -q ${daemon_tmux_session}"
+rc_start() {
+	rc_exec "${pexp} >$daemon_log 2>&1 & "
 }
 
 rc_cmd $1


### PR DESCRIPTION
This PR adds a mediocre rc.d script for running the bot on OpenBSD.

Of note:
- Don't use `rcctl set furcast_bot flags` to change the flags, since the config file doesn't come from there.